### PR TITLE
Fix docs to match API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ async function main() {
   const client = new Client({
     user: "user",
     database: "test",
-    host: "localhost",
+    hostname: "localhost",
     port: "5432"
   });
   await client.connect();
@@ -43,7 +43,7 @@ import { Client } from "https://deno.land/x/postgres/mod.ts";
 let config;
 
 config = {
-  host: "localhost",
+  hostname: "localhost",
   port: "5432",
   user: "user",
   database: "test",


### PR DESCRIPTION
Currently the website: https://deno-postgres.com/#/?id=queries
Has the following example:
```ts
import { Client } from "https://deno.land/x/postgres/mod.ts";

async function main() {
  const client = new Client({
    user: "user",
    database: "test",
    host: "localhost",
    port: "5432"
  });
  await client.connect();
  const result = await client.query("SELECT * FROM people;");
  console.log(result.rows);
  await client.end();
}

main();
```

But when running the example locally it fails with the following error:
```
error: TS2345 [ERROR]: Argument of type '{ user: string; database: string; host: string; port: number; }' is not assignable to parameter of type 'string | ConnectionOptions | undefined'.
  Object literal may only specify known properties, and 'host' does not exist in type 'ConnectionOptions'.
    host: "localhost",
    ~~~~~~~~~~~~~~~~~
```

Based on the following function:
https://github.com/deno-postgres/deno-postgres/blob/d23393ec888b9f8e39aa0a9269be4ce728e28d8b/connection_params.ts#L115

And testing locally I found that the correct property is `hostname` instead.
