### PR TITLE
Add db result interface

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,6 +1,6 @@
 import { Connection } from "./connection.ts";
 import { ConnectionOptions, createParams } from "./connection_params.ts";
-import { Query, QueryConfig, QueryResult } from "./query.ts";
+import { IQueryResult, Query, QueryConfig, QueryResult} from "./query.ts";
 
 export class Client {
   protected _connection: Connection;
@@ -20,7 +20,7 @@ export class Client {
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<QueryResult> {
+  ): Promise<IQueryResult> {
     const query = new Query(text, ...args);
     return await this._connection.query(query);
   }

--- a/client.ts
+++ b/client.ts
@@ -1,6 +1,6 @@
 import { Connection } from "./connection.ts";
 import { ConnectionOptions, createParams } from "./connection_params.ts";
-import { IQueryResult, Query, QueryConfig, QueryResult} from "./query.ts";
+import { IQueryResult, Query, QueryConfig, QueryResult } from "./query.ts";
 
 export class Client {
   protected _connection: Connection;

--- a/client.ts
+++ b/client.ts
@@ -20,7 +20,7 @@ export class Client {
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<IQueryResult> {
+  ): Promise<QueryResult> {
     const query = new Query(text, ...args);
     return await this._connection.query(query);
   }

--- a/connection.ts
+++ b/connection.ts
@@ -30,7 +30,7 @@ import { BufReader, BufWriter, Hash } from "./deps.ts";
 import { PacketWriter } from "./packet_writer.ts";
 import { hashMd5Password, readUInt32BE } from "./utils.ts";
 import { PacketReader } from "./packet_reader.ts";
-import { QueryConfig, QueryResult, Query } from "./query.ts";
+import { QueryConfig, QueryResult, Query, IQueryResult } from "./query.ts";
 import { parseError } from "./error.ts";
 import { ConnectionParams } from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,4 @@
 export { Client } from "./client.ts";
 export { PostgresError } from "./error.ts";
 export { Pool } from "./pool.ts";
+export { IQueryResult } from "./query.ts"

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
 export { Client } from "./client.ts";
 export { PostgresError } from "./error.ts";
 export { Pool } from "./pool.ts";
-export { IQueryResult } from "./query.ts"
+export { IQueryResult } from "./query.ts";

--- a/pool.ts
+++ b/pool.ts
@@ -6,7 +6,7 @@ import {
   createParams,
 } from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";
-import { Query, QueryConfig, QueryResult } from "./query.ts";
+import {IQueryResult, Query, QueryConfig, QueryResult} from "./query.ts";
 
 export class Pool {
   private _connectionParams: ConnectionParams;

--- a/pool.ts
+++ b/pool.ts
@@ -6,7 +6,7 @@ import {
   createParams,
 } from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";
-import {IQueryResult, Query, QueryConfig, QueryResult} from "./query.ts";
+import { IQueryResult, Query, QueryConfig, QueryResult } from "./query.ts";
 
 export class Pool {
   private _connectionParams: ConnectionParams;

--- a/query.ts
+++ b/query.ts
@@ -28,7 +28,7 @@ export interface IQueryResult {
   _done: boolean;
   rows: any[];
   rowCount?: number;
-  command: CommandType
+  command: CommandType;
 }
 
 export class QueryResult {

--- a/query.ts
+++ b/query.ts
@@ -23,6 +23,14 @@ export interface QueryConfig {
   encoder?: (arg: unknown) => EncodedArg;
 }
 
+export interface IQueryResult {
+  rowDescription: RowDescription;
+  _done: boolean;
+  rows: any[];
+  rowCount?: number;
+  command: CommandType
+}
+
 export class QueryResult {
   public rowDescription!: RowDescription;
   private _done = false;

--- a/query.ts
+++ b/query.ts
@@ -26,6 +26,7 @@ export interface QueryConfig {
 export interface IQueryResult {
   rowDescription: RowDescription;
   _done: boolean;
+  // deno-lint-ignore no-explicit-any
   rows: any[];
   rowCount?: number;
   command: CommandType;

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -38,8 +38,8 @@ testPool(async function parametrizedQuery(POOL) {
   const result = await POOL.query("SELECT * FROM ids WHERE id < $1;", 2);
   assertEquals(result.rows.length, 1);
 
-  const queryResult = new QueryResult(new Query("", []))
-  queryResult.rows = result.rows
+  const queryResult = new QueryResult(new Query("", []));
+  queryResult.rows = result.rows;
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -5,6 +5,7 @@ import {
 import { Pool } from "../pool.ts";
 import { delay } from "../utils.ts";
 import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
+import { Query, QueryResult } from "../query.ts";
 
 async function testPool(
   t: (pool: Pool) => void | Promise<void>,
@@ -37,7 +38,9 @@ testPool(async function parametrizedQuery(POOL) {
   const result = await POOL.query("SELECT * FROM ids WHERE id < $1;", 2);
   assertEquals(result.rows.length, 1);
 
-  const objectRows = result.rowsOfObjects();
+  const queryResult = new QueryResult(new Query("", []))
+  queryResult.rows = result.rows
+  const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 
   assertEquals(row.id, 1);

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -40,6 +40,7 @@ testPool(async function parametrizedQuery(POOL) {
 
   const queryResult = new QueryResult(new Query("", []));
   queryResult.rows = result.rows;
+  queryResult.rowDescription = result.rowDescription
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -40,7 +40,7 @@ testPool(async function parametrizedQuery(POOL) {
 
   const queryResult = new QueryResult(new Query("", []));
   queryResult.rows = result.rows;
-  queryResult.rowDescription = result.rowDescription
+  queryResult.rowDescription = result.rowDescription;
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -1,8 +1,8 @@
-import {Client, IQueryResult} from "../mod.ts";
+import { Client, IQueryResult } from "../mod.ts";
 import { assertEquals } from "../test_deps.ts";
 import { DEFAULT_SETUP, TEST_CONNECTION_PARAMS } from "./constants.ts";
 import { getTestClient } from "./helpers.ts";
-import { Query, QueryResult} from "../query.ts";
+import { Query, QueryResult } from "../query.ts";
 
 const CLIENT = new Client(TEST_CONNECTION_PARAMS);
 
@@ -14,11 +14,14 @@ testClient(async function simpleQuery() {
 });
 
 testClient(async function parametrizedQuery() {
-  const result: IQueryResult|QueryResult = await CLIENT.query("SELECT * FROM ids WHERE id < $1;", 2);
+  const result: IQueryResult | QueryResult = await CLIENT.query(
+    "SELECT * FROM ids WHERE id < $1;",
+    2,
+  );
   assertEquals(result.rows.length, 1);
 
-  const queryResult = new QueryResult(new Query("", []))
-  queryResult.rows = result.rows
+  const queryResult = new QueryResult(new Query("", []));
+  queryResult.rows = result.rows;
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 
@@ -141,7 +144,7 @@ testClient(async function multiQueryWithManyQueryTypeArray() {
 });
 
 testClient(async function resultMetadata() {
-  let result: IQueryResult|QueryResult;
+  let result: IQueryResult | QueryResult;
 
   // simple select
   result = await CLIENT.query("SELECT * FROM ids WHERE id = 100");

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -1,8 +1,8 @@
-import { Client } from "../mod.ts";
+import {Client, IQueryResult} from "../mod.ts";
 import { assertEquals } from "../test_deps.ts";
 import { DEFAULT_SETUP, TEST_CONNECTION_PARAMS } from "./constants.ts";
 import { getTestClient } from "./helpers.ts";
-import { QueryResult } from "../query.ts";
+import { Query, QueryResult} from "../query.ts";
 
 const CLIENT = new Client(TEST_CONNECTION_PARAMS);
 
@@ -14,10 +14,12 @@ testClient(async function simpleQuery() {
 });
 
 testClient(async function parametrizedQuery() {
-  const result = await CLIENT.query("SELECT * FROM ids WHERE id < $1;", 2);
+  const result: IQueryResult|QueryResult = await CLIENT.query("SELECT * FROM ids WHERE id < $1;", 2);
   assertEquals(result.rows.length, 1);
 
-  const objectRows = result.rowsOfObjects();
+  const queryResult = new QueryResult(new Query("", []))
+  queryResult.rows = result.rows
+  const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 
   assertEquals(row.id, 1);
@@ -139,7 +141,7 @@ testClient(async function multiQueryWithManyQueryTypeArray() {
 });
 
 testClient(async function resultMetadata() {
-  let result: QueryResult;
+  let result: IQueryResult|QueryResult;
 
   // simple select
   result = await CLIENT.query("SELECT * FROM ids WHERE id = 100");

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -22,7 +22,7 @@ testClient(async function parametrizedQuery() {
 
   const queryResult = new QueryResult(new Query("", []));
   queryResult.rows = result.rows;
-  queryResult.rowDescription = result.rowDescription
+  queryResult.rowDescription = result.rowDescription;
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -22,6 +22,7 @@ testClient(async function parametrizedQuery() {
 
   const queryResult = new QueryResult(new Query("", []));
   queryResult.rows = result.rows;
+  queryResult.rowDescription = result.rowDescription
   const objectRows = queryResult.rowsOfObjects();
   const row = objectRows[0];
 


### PR DESCRIPTION
Fixes #145 

Added a database result (query result) interface.

It can be used like so. (user implementation):

```typescript
import { IQueryResult } from "https:deno.land/x/postgres@<new_version>/mod.ts";
const result: IQueryResult = await. client.query("SELECT * FROM users");
// we can now check `rowCount` without errors or additional logic
if (result.rowCount < 1) {
  throw new Error("No result from db")
}
```

This came about as i wanted to use `rowCount` following the new feature implementation, to ensure our queries were successful, but ran into TS errors that i felt would be much better solvable using an interface