### PR TITLE
chore: bump Deno to v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install deno
         uses: denolib/setup-deno@master
         with: 
-          deno-version: 1.1.0
+          deno-version: 1.2.0
 
       - name: Check formatting
         run: deno fmt --check

--- a/array_parser.ts
+++ b/array_parser.ts
@@ -27,10 +27,10 @@ export function parseArray(source: string, transform: Function | undefined) {
 class ArrayParser {
   source: string;
   transform: Function;
-  position: number = 0;
+  position = 0;
   entries: Array<unknown> = [];
   recorded: Array<unknown> = [];
-  dimension: number = 0;
+  dimension = 0;
 
   constructor(source: string, transform: Function | undefined) {
     this.source = source;
@@ -59,7 +59,7 @@ class ArrayParser {
     this.recorded.push(character);
   }
 
-  newEntry(includeEmpty: boolean = false): void {
+  newEntry(includeEmpty = false): void {
     let entry;
     if (this.recorded.length > 0 || includeEmpty) {
       entry = this.recorded.join("");

--- a/deps.ts
+++ b/deps.ts
@@ -1,13 +1,13 @@
 export {
   BufReader,
   BufWriter,
-} from "https://deno.land/std@0.51.0/io/bufio.ts";
+} from "https://deno.land/std@0.61.0/io/bufio.ts";
 
-export { copyBytes } from "https://deno.land/std@0.51.0/io/util.ts";
+export { copyBytes } from "https://deno.land/std@0.61.0/bytes/mod.ts";
 
 export {
   Deferred,
   deferred,
-} from "https://deno.land/std@0.51.0/async/deferred.ts";
+} from "https://deno.land/std@0.61.0/async/deferred.ts";
 
 export { Hash } from "https://deno.land/x/checksum@1.2.0/mod.ts";

--- a/packet_reader.ts
+++ b/packet_reader.ts
@@ -1,7 +1,7 @@
 import { readInt16BE, readInt32BE } from "./utils.ts";
 
 export class PacketReader {
-  private offset: number = 0;
+  private offset = 0;
   private decoder: TextDecoder = new TextDecoder();
 
   constructor(private buffer: Uint8Array) {}

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -2,7 +2,7 @@ export * from "./deps.ts";
 export {
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringContains,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.51.0/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -1,6 +1,6 @@
 const { test } = Deno;
 import { Client, PostgresError } from "../mod.ts";
-import { assert, assertStrContains } from "../test_deps.ts";
+import { assert, assertStringContains } from "../test_deps.ts";
 import { TEST_CONNECTION_PARAMS } from "./constants.ts";
 
 test("badAuthData", async function () {
@@ -15,7 +15,7 @@ test("badAuthData", async function () {
   } catch (e) {
     thrown = true;
     assert(e instanceof PostgresError);
-    assertStrContains(e.message, "password authentication failed for user");
+    assertStringContains(e.message, "password authentication failed for user");
   } finally {
     await client.end();
   }


### PR DESCRIPTION
- Bumped Deno to v1.2.0 in CI.
- Bumped std to v0.61.0.
  - `copyBytes` has been moved from `std/io/util.ts` to `std/bytes/mod.ts`.
  - `assertStrContains` has been renamed to `assertStringContains`.
- Fixed `array_parser.ts` and `packet_reader.ts` to pass "deno lint".