### PR TITLE
Bump Deno to v1.2.2, replace checksum lib for std/hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install deno
         uses: denolib/setup-deno@master
         with: 
-          deno-version: 1.2.0
+          deno-version: 1.2.2
 
       - name: Check formatting
         run: deno fmt --check

--- a/connection.ts
+++ b/connection.ts
@@ -26,7 +26,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { BufReader, BufWriter, Hash } from "./deps.ts";
+import { BufReader, BufWriter } from "./deps.ts";
 import { PacketWriter } from "./packet_writer.ts";
 import { hashMd5Password, readUInt32BE } from "./utils.ts";
 import { PacketReader } from "./packet_reader.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,13 +1,10 @@
 export {
   BufReader,
   BufWriter,
-} from "https://deno.land/std@0.61.0/io/bufio.ts";
-
-export { copyBytes } from "https://deno.land/std@0.61.0/bytes/mod.ts";
-
+} from "https://deno.land/std@0.63.0/io/bufio.ts";
+export { copyBytes } from "https://deno.land/std@0.63.0/bytes/mod.ts";
 export {
   Deferred,
   deferred,
-} from "https://deno.land/std@0.61.0/async/deferred.ts";
-
-export { Hash } from "https://deno.land/x/checksum@1.2.0/mod.ts";
+} from "https://deno.land/std@0.63.0/async/deferred.ts";
+export { createHash } from "https://deno.land/std@0.63.0/hash/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,4 +5,4 @@ export {
   assertStringContains,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,4 @@
-import { Hash } from "./deps.ts";
+import { createHash } from "./deps.ts";
 
 export function readInt16BE(buffer: Uint8Array, offset: number): number {
   offset = offset >>> 0;
@@ -36,7 +36,7 @@ export function readUInt32BE(buffer: Uint8Array, offset: number): number {
 const encoder = new TextEncoder();
 
 function md5(bytes: Uint8Array): string {
-  return new Hash("md5").digest(bytes).hex();
+  return createHash("md5").update(bytes).toString("hex");
 }
 
 // https://www.postgresql.org/docs/current/protocol-flow.html


### PR DESCRIPTION
- Replaced x/checksum library for std/hash implementation
- Upgraded Deno to v1.2.2 and std to v0.63.0

### Important
Please add a release tag to this so people don't have to pull from master or commit hash
(_Real shocking images_)
![image](https://user-images.githubusercontent.com/42647963/89082782-a78d7280-d354-11ea-817d-78b572262ca4.png)
