### PR TITLE
Documentation: Port is of type number but examples uses string

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ async function main() {
     user: "user",
     database: "test",
     hostname: "localhost",
-    port: "5432"
+    port: 5432
   });
   await client.connect();
   const result = await client.query("SELECT * FROM people;");
@@ -85,7 +85,7 @@ let config;
 
 config = {
   hostname: "localhost",
-  port: "5432",
+  port: 5432,
   user: "user",
   database: "test",
   applicationName: "my_custom_app"


### PR DESCRIPTION
The port field in the client object is of type `number` but in the examples it is showcased as a string
```javascript
 const client = new Client({
    user: "user",
    database: "test",
    hostname: "localhost",
    port: "5432"
  });
```
Which raised the following error on build: 
`error: Uncaught InvalidData: data did not match any variant of untagged enum ArgsEnum`

