### PR TITLE
chore: update for deno 1.3.0 & std 0.67.0 (resolves #165)

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -609,9 +609,5 @@ export class Connection {
     await this.bufWriter.write(terminationMessage);
     await this.bufWriter.flush();
     this.conn.close();
-    delete this.conn;
-    delete this.bufReader;
-    delete this.bufWriter;
-    delete this.packetWriter;
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,10 +1,10 @@
 export {
   BufReader,
   BufWriter,
-} from "https://deno.land/std@0.63.0/io/bufio.ts";
-export { copyBytes } from "https://deno.land/std@0.63.0/bytes/mod.ts";
+} from "https://deno.land/std@0.67.0/io/bufio.ts";
+export { copyBytes } from "https://deno.land/std@0.67.0/bytes/mod.ts";
 export {
   Deferred,
   deferred,
-} from "https://deno.land/std@0.63.0/async/deferred.ts";
-export { createHash } from "https://deno.land/std@0.63.0/hash/mod.ts";
+} from "https://deno.land/std@0.67.0/async/deferred.ts";
+export { createHash } from "https://deno.land/std@0.67.0/hash/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,4 +5,4 @@ export {
   assertStringContains,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.63.0/testing/asserts.ts";
+} from "https://deno.land/std@0.67.0/testing/asserts.ts";


### PR DESCRIPTION
This updates the std dependencies to 0.67.0, to work with Deno 1.3.0.

The only notable change required for this is the removal of the `delete` statements for various non-null asserted members of the `Connection` class. TS4.0 made deleting non-optional members a compile-time error.

Resolves #165