### PR TITLE
Fixed Bug in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,8 +61,8 @@ async function runQuery (query: string) {
   return dbResult
 }
 
-runQuery("SELECT * FROM users;");
-runQuery("SELECT * FROM users WHERE id = '1';");
+await runQuery("SELECT * FROM users;");
+await runQuery("SELECT * FROM users WHERE id = '1';");
 ```
 
 This improves performance, as creating a whole new connection for each query can be an expensive operation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ const dbPool = new Pool({
   port: 5432,
 }, POOL_CONNECTIONS);
 
-function runQuery (query: string) {
+async function runQuery (query: string) {
   const client: PoolClient = await dbPool.connect();
   const dbResult = await client.query(query);
   client.release();


### PR DESCRIPTION
Ther error in documentation explicitly used `await` in a non async function. This means that the examples are incorrect and should be fixed.

BEFORE:
```typescript
import { Pool } from "https://deno.land/x/postgres@v0.4.0/mod.ts";
import { PoolClient } from "https://deno.land/x/postgres@v0.4.0/client.ts";

const POOL_CONNECTIONS = 20;
const dbPool = new Pool({
  user: "user",
  password: "password",
  database: "database",
  hostname: "hostname",
  port: 5432,
}, POOL_CONNECTIONS);

function runQuery (query: string) {
  const client: PoolClient = await dbPool.connect();
  const dbResult = await client.query(query);
  client.release();
  return dbResult
}

runQuery("SELECT * FROM users;");
runQuery("SELECT * FROM users WHERE id = '1';");
```
AFTER:
```typescript
import { Pool } from "https://deno.land/x/postgres@v0.4.0/mod.ts";
import { PoolClient } from "https://deno.land/x/postgres@v0.4.0/client.ts";

const POOL_CONNECTIONS = 20;
const dbPool = new Pool({
  user: "user",
  password: "password",
  database: "database",
  hostname: "hostname",
  port: 5432,
}, POOL_CONNECTIONS);

async function runQuery (query: string) {
  const client: PoolClient = await dbPool.connect();
  const dbResult = await client.query(query);
  client.release();
  return dbResult
}

runQuery("SELECT * FROM users;");
runQuery("SELECT * FROM users WHERE id = '1';");
```